### PR TITLE
Add roadmap and development tracking docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ This project uses a collaborative AI development approach with three dedicated s
 - **[OpenAI Codex](AGENTS.md)**: Responsible for planning, roadmap management, and high-level project direction.
 - **[Claude Code](CLAUDE.md)**: Responsible for writing code implementations and test coverage.
 - **[GitHub Copilot](.github/copilot-instructions.md)**: Responsible for reviewing commit diffs and pull requests for consistency and style.
+
+## Project Roadmap
+
+The planning and tracking documents live in the [docs](docs/) directory:
+
+- [Good Vibes Roadmap](docs/ROADMAP.md)
+- [Development Tracking Guide](docs/DEVELOPMENT_TRACKING.md)
+
+These files are updated regularly by the AI agents to keep progress transparent and aligned with the project's goals.

--- a/docs/DEVELOPMENT_TRACKING.md
+++ b/docs/DEVELOPMENT_TRACKING.md
@@ -1,0 +1,35 @@
+# Development Tracking Guide
+
+This guide describes how tasks and progress are tracked in the Good Vibes project. It complements the main [roadmap](ROADMAP.md) and focuses on keeping development steps organized for the AI agents.
+
+## Task Structure
+
+- **Module Reference**: Each task references a module from the roadmap.
+- **Scope**: Tasks are small and focused, usually involving a single feature or improvement.
+- **Documentation**: Updates or new tasks are documented directly in the repository so future agents can pick up where previous ones left off.
+
+## Updating Tasks
+
+1. **Codex** identifies upcoming work in `docs/ROADMAP.md` and adds or refines tasks in this file.
+2. **Claude Code** implements the code changes and associated tests.
+3. **GitHub Copilot** reviews the pull request, suggesting improvements when necessary.
+4. After merging, the task status is updated here to reflect completion.
+
+## Example Entry
+
+```
+- [ ] Introduce navigation component (Module: Core Layout)
+  - [ ] Create HTML structure
+  - [ ] Add CSS styles
+  - [ ] Implement JavaScript toggle logic
+```
+
+Checkboxes allow progress to be tracked over multiple commits or pull requests. Finished items can be checked off and dated if desired.
+
+## Best Practices
+
+- Keep each entry short and clear so it is easy for any agent to continue the work.
+- When closing a task, provide a brief note about the implementation (file names or PR reference).
+- Review this guide regularly to ensure it matches the actual project state.
+
+This tracking approach ensures iterative progress without strict deadlines, allowing the AI agents to maintain momentum while keeping documentation in sync with the codebase.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,46 @@
+# Good Vibes Roadmap
+
+This roadmap outlines planned modules and sub-components for the Good Vibes single-page application (SPA). It is maintained by **OpenAI Codex** with input from **Claude Code** and **GitHub Copilot**. Changes to this file should reflect the current understanding of project priorities and structure.
+
+## Modules
+
+Each numbered item represents a module of work that can be tracked separately in the repository. Sub-items describe related tasks or components.
+
+1. **Core Layout**
+   - Basic HTML structure with header, footer, and central content container.
+   - Shared navigation elements for switching between sections.
+   - Global styles and variables.
+2. **Introduction Section**
+   - Content describing vibe coding and the purpose of Good Vibes.
+   - Styling rules for headings, paragraphs, and images within this section.
+3. **GitHub Repositories Listing**
+   - Fetch and display a list of related repositories from GitHub.
+   - Provide links and brief descriptions for each repository.
+   - Consider caching results or providing a fallback for offline viewing.
+4. **Articles Section**
+   - Markdown-driven or HTML-based articles about the vibe coding journey.
+   - Navigation for multiple articles and an index or landing page.
+   - Optionally include syntax highlighting for code snippets.
+5. **Utilities and Helpers**
+   - JavaScript modules for data fetching, DOM manipulation, or animations.
+   - CSS helpers and mixins to keep styling consistent.
+6. **Build and Testing Setup**
+   - Configuration for development tooling (linters, bundlers, etc.).
+   - Automated tests for core functionality.
+
+## Collaboration Roles
+
+- **OpenAI Codex** updates this roadmap and suggests structural changes or new modules as the project evolves.
+- **Claude Code** implements the modules, writes tests, and keeps code organized according to the roadmap.
+- **GitHub Copilot** reviews pull requests for style and best practices, flagging inconsistencies or areas for improvement.
+
+## Tracking Modules
+
+Each module or sub-component should be tracked as a discrete task. Typical workflow:
+
+1. Codex outlines or updates a module in this roadmap.
+2. Claude Code creates or updates source files to implement the module and accompanying tests.
+3. GitHub Copilot reviews the commit or pull request for style, clarity, and adherence to project guidelines.
+4. Once merged, this roadmap is updated to reflect progress or introduce the next tasks.
+
+Roadmap updates and implementation details should remain small in scope to keep iterations easy to review and merge.


### PR DESCRIPTION
## Summary
- outline SPA modules and AI roles in docs/ROADMAP.md
- add docs/DEVELOPMENT_TRACKING.md for task progress
- link to docs from README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68661f8f94988321ade71a4139df612b